### PR TITLE
Tutorial: update schedule as discussed in #1546

### DIFF
--- a/content/tutorial/_index.md
+++ b/content/tutorial/_index.md
@@ -6,7 +6,7 @@ template="tutorial.html"
 *At [PLDI 2023][pldi-home] in Orlando*
 
 **When**: **Sunday June 18, 2023; morning session** <br/>
-**Where**: **Magnolia 9**
+**Where**: **Magnolia 9, with a virtual option (see below)**
 
 In the last four decades, the easiest way to improve performance of programs has been to simply wait; processor and process scaling took care of the rest.
 Sadly, Moore's law is over, there are no free lunches left, and everyone at the table is desperate.


### PR DESCRIPTION
I have put in the changes we discussed, plus:
1. I've added links to Cider and MrXL documentation for those following at their own pace. 
2. I found that the schedule was getting a little busy because of super short slots that we care about internally but the attendees won't notice (e.g. where does intro to Calyx end and Calyx machine setup begin, or where does the MrXL extension lesson end and the MrXL contest begin) so I have merged a few slots. Let me know if that's no bueno :)

Closes https://github.com/cucapra/calyx/issues/1546 over in the Calyx repo