### PR TITLE
Add in publications tab and citations

### DIFF
--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -3,5 +3,5 @@ title = "Calyx Blog"
 sort_by = "date"
 template = "post.html"
 page_template = "post-page.html"
-generate_feed = true
+generate_feeds = true
 +++

--- a/content/publications/_index.md
+++ b/content/publications/_index.md
@@ -5,34 +5,27 @@ template = "publications.html"
 
 # Publications
 
-[Understanding Accelerator Compilers via Performance Profiling](https://arxiv.org/abs/2511.19764)
+- [Understanding Accelerator Compilers via Performance Profiling](https://arxiv.org/abs/2511.19764)
 Ayaka Yorihiro, Griffin Berlstein, Pedro Pontes García, Kevin Laufer, Adrian Sampson.
 *arXiv preprint*
-
-[From PyTorch to Calyx: An Open-Source Compiler Toolchain for ML Accelerators](https://arxiv.org/abs/2512.06177)
+- [From PyTorch to Calyx: An Open-Source Compiler Toolchain for ML Accelerators](https://arxiv.org/abs/2512.06177)
 Jiahan Xie, Evan Williams, Adrian Sampson.
 [*Workshop on Compilers for Machine Learning (C4ML) 2026*](https://c4ml.org/)
-
-[From PyTorch to Calyx: An Open-Source Compiler Toolchain for ML Accelerators](https://accml.dcs.gla.ac.uk/papers/2026/8th_AccML_paper_7.pdf)
+- [From PyTorch to Calyx: An Open-Source Compiler Toolchain for ML Accelerators](https://accml.dcs.gla.ac.uk/papers/2026/8th_AccML_paper_7.pdf)
 Jiahan Xie, Evan Williams, Adrian Sampson.
 [*Workshop on Accelerated Machine Learning (AccML) 2026*](https://accml.dcs.gla.ac.uk/)
-
-[A FIRRTL Backend for the Calyx High-Level Accelerator Compilation Infrastructure](https://ayakayorihiro.github.io/files/publications/calyx-firrtl.pdf)
+- [A FIRRTL Backend for the Calyx High-Level Accelerator Compilation Infrastructure](https://ayakayorihiro.github.io/files/publications/calyx-firrtl.pdf)
 Ayaka Yorihiro, Griffin Berlstein, Kevin Laeufer, Adrian Sampson.
 [*Workshop on Open-Source Design Automation (OSDA) 2024*](https://osda.ws/events/2024/date/accepted-papers)
-
-[Unifying Static and Dynamic Intermediate Languages for Accelerator Generators](https://dl.acm.org/doi/10.1145/3689790)
+- [Unifying Static and Dynamic Intermediate Languages for Accelerator Generators](https://dl.acm.org/doi/10.1145/3689790)
 Caleb Kim, Pai Li, Anshuman Mohan, Andrew Butt, Adrian Sampson, Rachit Nigam.
 *International Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA) 2023*
-
-[Stepwise Debugging for Hardware Accelerators](https://dl.acm.org/doi/10.1145/3575693.3575717)
+- [Stepwise Debugging for Hardware Accelerators](https://dl.acm.org/doi/10.1145/3575693.3575717)
 Griffin Berlstein, Rachit Nigam, Chrisophe Gyurgyik, Adrian Sampson.
 *International Conference on Architectural Support for Programming Languages and Operating Systems (ASPLOS) 2023*
-
-[A Toolkit for Designing Hardware DSLs](https://griffinberlste.in/pdf/calyx-woset.pdf)
+- [A Toolkit for Designing Hardware DSLs](https://griffinberlste.in/pdf/calyx-woset.pdf)
 Griffin Berlstein, Rachit Nigam, Chrisophe Gyurgyik, Adrian Sampson.
 *[Workshop on Open-Source EDA Technology (WOSET) 2021](https://woset-workshop.github.io/WOSET2021.html)*
-
-[Calyx: A Language for Hardware Accelerator Generators](https://dl.acm.org/doi/10.1145/3445814.3446712)
+- [Calyx: A Language for Hardware Accelerator Generators](https://dl.acm.org/doi/10.1145/3445814.3446712)
 Rachit Nigam, Samuel Thomas, Zhijing Li, Adrian Sampson.
 *International Conference on Architectural Support for Programming Languages and Operating Systems (ASPLOS) 2021*

--- a/content/publications/_index.md
+++ b/content/publications/_index.md
@@ -1,0 +1,38 @@
++++
+title = "Publications"
+template = "publications.html"
++++
+
+# Publications
+
+[Understanding Accelerator Compilers via Performance Profiling](https://arxiv.org/abs/2511.19764)
+Ayaka Yorihiro, Griffin Berlstein, Pedro Pontes García, Kevin Laufer, Adrian Sampson.
+*arXiv preprint*
+
+[From PyTorch to Calyx: An Open-Source Compiler Toolchain for ML Accelerators](https://arxiv.org/abs/2512.06177)
+Jiahan Xie, Evan Williams, Adrian Sampson.
+[*Workshop on Compilers for Machine Learning (C4ML) 2026*](https://c4ml.org/)
+
+[From PyTorch to Calyx: An Open-Source Compiler Toolchain for ML Accelerators](https://accml.dcs.gla.ac.uk/papers/2026/8th_AccML_paper_7.pdf)
+Jiahan Xie, Evan Williams, Adrian Sampson.
+[*Workshop on Accelerated Machine Learning (AccML) 2026*](https://accml.dcs.gla.ac.uk/)
+
+[A FIRRTL Backend for the Calyx High-Level Accelerator Compilation Infrastructure](https://ayakayorihiro.github.io/files/publications/calyx-firrtl.pdf)
+Ayaka Yorihiro, Griffin Berlstein, Kevin Laeufer, Adrian Sampson.
+[*Workshop on Open-Source Design Automation (OSDA) 2024*](https://osda.ws/events/2024/date/accepted-papers)
+
+[Unifying Static and Dynamic Intermediate Languages for Accelerator Generators](https://dl.acm.org/doi/10.1145/3689790)
+Caleb Kim, Pai Li, Anshuman Mohan, Andrew Butt, Adrian Sampson, Rachit Nigam.
+*International Conference on Object-Oriented Programming, Systems, Languages, and Applications (OOPSLA) 2023*
+
+[Stepwise Debugging for Hardware Accelerators](https://dl.acm.org/doi/10.1145/3575693.3575717)
+Griffin Berlstein, Rachit Nigam, Chrisophe Gyurgyik, Adrian Sampson.
+*International Conference on Architectural Support for Programming Languages and Operating Systems (ASPLOS) 2023*
+
+[A Toolkit for Designing Hardware DSLs](https://griffinberlste.in/pdf/calyx-woset.pdf)
+Griffin Berlstein, Rachit Nigam, Chrisophe Gyurgyik, Adrian Sampson.
+*[Workshop on Open-Source EDA Technology (WOSET) 2021](https://woset-workshop.github.io/WOSET2021.html)*
+
+[Calyx: A Language for Hardware Accelerator Generators](https://dl.acm.org/doi/10.1145/3445814.3446712)
+Rachit Nigam, Samuel Thomas, Zhijing Li, Adrian Sampson.
+*International Conference on Architectural Support for Programming Languages and Operating Systems (ASPLOS) 2021*

--- a/templates/base.html
+++ b/templates/base.html
@@ -35,7 +35,7 @@
     </h3>
     <hr/>
     <nav>
-      <a class="nav-item" href="https://dl.acm.org/doi/10.1145/3445814.3446712">Paper</a>
+      <a class="nav-item" href="{{ get_url(path="/publications") | safe }}">Publications</a>
       <a class="nav-item" href="https://github.com/cucapra/calyx">Code</a>
       <a class="nav-item" href="https://docs.calyxir.org">Documentation</a>
       <a class="nav-item" href="https://github.com/cucapra/calyx/discussions">Discussions</a>

--- a/templates/publications.html
+++ b/templates/publications.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+{{ section.content | safe }}
+{% endblock content %}


### PR DESCRIPTION
Added in a publications tab:

<img width="994" height="783" alt="image" src="https://github.com/user-attachments/assets/974ce853-14f1-4848-9986-90c8260363a4" />

Some other websites with publication tabs have little drop-downs with the BibTeX citation or links to presentations, slides, videos, etc. See: 
- https://stanford-ppl.github.io/website/#publications
- http://tensor-compiler.org/publications.html
- https://halide-lang.org/#publications

Let me know if such a thing would be helpful and I'd be happy to try it out! 